### PR TITLE
Fix rst markup for PyPI

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,19 +3,19 @@ CHANGELOG
 =========
 
 0.3 (unreleased)
-================
+----------------
 
 - Nothing changed yet.
 
 
 0.2 (2016-08-22)
-================
+----------------
 
 - Made svglib installable via pip. Thanks to Adrien Cossa for the bug report.
 
 
 0.1 (2016-03-10)
-================
+----------------
 
 - Fork of https://github.com/borgar/svglib
 

--- a/README.txt
+++ b/README.txt
@@ -4,9 +4,7 @@
 Svglib3
 =======
 
--------------------------------------------------------------------------
-A branch of svglib with a fixed missing import and Python 3 compatability
--------------------------------------------------------------------------
+*A branch of svglib with a fixed missing import and Python 3 compatability*
 
 About
 -----


### PR DESCRIPTION
PyPI is picky about the rst markup in the long description - if it detects a problem, it falls back to rendering as plain text. This is why the project's [PyPI page](https://pypi.python.org/pypi/svglib3/0.2.0) looks ugly.

These changes should make the rst work if another release is uploaded. I checked it with the [readme_renderer](https://pypi.python.org/pypi/readme_renderer) package.
